### PR TITLE
Add option to rewrite From: header

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To use this, you'll need an existing mailserver and some way to authenticate to 
 | `mailclient_system_owner` | `False` | All system mail (see below) will be redirected owner@domain |
 | `mailclient_to_redirect` | (see defaults/main.yml) | Which accounts to redirect mail for? |
 | `mailclient_relay` | `False` | Relay mail over this system (postfix relayhost syntax) |
+| `mailclient_rewrite_from_header` | `False` | Rewrite the `From:` header on outgoing mails |
 | `mailclient_auth_enable` | `yes` | Whether to authenticate at the relay host |
 | `mailclient_auth_mechanism` | `gssapi` | How to authenticate with the relay host |
 | `mailclient_auth_credentials` | (see defaults/main.yml) | Login for the relay host |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,9 @@ mailclient_to_redirect:
 # Relay mail over this sustem (postfix relayhost syntax)
 mailclient_relay: False
 
+# Rewrite headers for outgoing mails
+mailclient_rewrite_from_header: False
+
 # Whether to enable auth
 mailclient_auth_enable: "yes"
 # Which SASL mechanisms to use

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -41,6 +41,14 @@
     notify:
       - restart postfix
 
+  - name: rebuild header map
+    become: True
+    command: postmap /etc/postfix/header_check
+    args:
+      chdir: /etc/postfix
+    notify:
+      - restart postfix
+
   - name: rebuild sasl map
     become: True
     command: postmap /etc/postfix/sasl_passwd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,16 @@
       - rebuild sender map
     tags: postfix
 
+  - name: Configure postfix
+    become: True
+    template: src='{{item}}.j2' dest='/etc/postfix/{{item}}' owner=root group=root mode=0644
+    when: mailclient_rewrite_from_header
+    with_items:
+      - header_check
+    notify:
+      - rebuild header map
+    tags: postfix
+
   - name: Store postfix auth credentials
     become: True
     when: mailclient_auth_enable == "yes"

--- a/templates/header_check.j2
+++ b/templates/header_check.j2
@@ -1,0 +1,2 @@
+# Managed by Ansible (role: mailclient), do not edit!
+/From:.*/ REPLACE From: {{ ansible_fqdn }} <{{ mailclient_sender }}@{{ mailclient_domain }}>

--- a/templates/main.cf.j2
+++ b/templates/main.cf.j2
@@ -114,5 +114,11 @@ smtp_sasl_security_options =
 import_environment = MAIL_CONFIG MAIL_DEBUG MAIL_LOGTAG TZ LANG=C KRB5CCNAME=FILE:{{ mailclient_auth_keytab_postfix }}
 {% endif %}
 
+{%- if mailclient_rewrite_from_header %}
+
+# Rewrite headers for outgoing mails
+smtp_header_checks = regexp:/etc/postfix/header_check
+{% endif %}
+
 # Rewrite mail to local users
 alias_database = hash:/etc/aliases


### PR DESCRIPTION
Add the `mailclient_rewrite_from_header` variable, which rewrites the
From: header for all mails as ansible_fqdn <sender@domain>.